### PR TITLE
Logout timer global fix

### DIFF
--- a/frontend/src/RootLayout.tsx
+++ b/frontend/src/RootLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "@tanstack/react-router"
+import AutoLogout from "./hooks/autoLogout"
+
+export default function RootLayout() {
+  return (
+    <>
+      <AutoLogout />
+      <Outlet />
+    </>
+  )
+}

--- a/frontend/src/hooks/autoLogout.tsx
+++ b/frontend/src/hooks/autoLogout.tsx
@@ -1,0 +1,41 @@
+import { useRef, useEffect } from "react"
+import useAuth from "./useAuth"
+
+function AutoLogout() {
+  const { user, logout } = useAuth()
+
+  const timerId = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const logout_time = (user?.auto_logout ?? 30) * 60 * 1000
+
+  const resetLogoutTimer = () => {
+    if (timerId.current) {
+      clearTimeout(timerId.current)
+    }
+    timerId.current = setTimeout(() => {
+      logout()
+    }, logout_time)
+  }
+
+  useEffect(() => {
+    if (localStorage.getItem("access_token")) {
+      resetLogoutTimer()
+
+      const handleActivity = () => {
+        resetLogoutTimer()
+      }
+
+      window.addEventListener("mousemove", handleActivity)
+
+      return () => {
+        window.removeEventListener("mousemove", handleActivity)
+        if (timerId.current) {
+          clearTimeout(timerId.current)
+        }
+      }
+    }
+  }, [logout_time, logout])
+
+  return null
+}
+
+export default AutoLogout

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import {useState, useRef, useEffect} from "react"
+import {useState
+  //, useRef,
+  //useEffect
+} from "react"
 
 import { AxiosError } from "axios"
 import {
@@ -88,7 +91,9 @@ const useAuth = () => {
     navigate({ to: "/login" })
   }
 
-  const timerID = useRef<NodeJS.Timeout | null>(null)
+  // leaving this commented in for a bit just in case
+
+/*  const timerID = useRef<NodeJS.Timeout | null>(null)
 
   const logout_timer_reset = () => {
     if (timerID.current) {
@@ -100,6 +105,9 @@ const useAuth = () => {
   }
 
   useEffect(() => {
+    if (location.pathname ===  "/signup") {
+      return
+    }
     if (localStorage.getItem("access_token")) {
       logout_timer_reset()
 
@@ -111,7 +119,7 @@ const useAuth = () => {
         clearTimeout(timerID.current)
       }
     }
-  }, [user]);
+  }, [user?.auto_logout]);*/
 
   return {
     signUpMutation,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,10 @@
 import { ChakraProvider } from "@chakra-ui/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { RouterProvider, createRouter } from "@tanstack/react-router"
+import { //createRouter,
+    RouterProvider,} from "@tanstack/react-router"
 import { createRoot } from "react-dom/client"
-import { routeTree } from "./routeTree.gen"
+//import {routeTree} from "./routeTree.gen.ts"
+import { router } from "./router.tsx"
 
 import { StrictMode } from "react"
 import { OpenAPI } from "./client"
@@ -15,7 +17,7 @@ OpenAPI.TOKEN = async () => {
 
 const queryClient = new QueryClient()
 
-const router = createRouter({ routeTree })
+//const router = createRouter({ routeTree })
 declare module "@tanstack/react-router" {
   interface Register {
     router: typeof router
@@ -26,7 +28,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ChakraProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <RouterProvider router={router}/>
       </QueryClientProvider>
     </ChakraProvider>
   </StrictMode>,

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,17 @@
+import { routeTree } from "./routeTree.gen.ts"
+import { createRouter } from "@tanstack/react-router"
+import RootLayout from "./RootLayout"
+
+routeTree.update({
+  component: RootLayout,
+})
+
+export const router = createRouter({
+  routeTree,
+})
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router
+  }
+}


### PR DESCRIPTION
This changes how the app layout is structured to mount AutoLogout.tsx to always be running for the logout timer. This is done through the additional files created, which make a new root that wraps out the current route tree, and imports that as our RouterProviders router. 