### PR TITLE
fixed incorrect email crash

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -121,9 +121,8 @@ function Login() {
 
         resetError()
 
-        const loginUser = await UsersService.readUserByEmail({email: data.username});
-
         try {
+            const loginUser = await UsersService.readUserByEmail({email: data.username});
             if (loginUser.is_2fa_enabled) {
                 const otp = generateOTP(); // Generate OTP and store it in a variable
                 setStoredOtp(otp); // Update state with the OTP


### PR DESCRIPTION
Checking 2FA was checking for a user with the given email without catching an error. I moved to get the user into the try-catch so it's caught, which should fix it.